### PR TITLE
refactored getPath() to use struct instead of regexp

### DIFF
--- a/assets/pora/server.go
+++ b/assets/pora/server.go
@@ -6,7 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
-	"regexp"
+	"encoding/json"
 	"strings"
 	"path/filepath"
 	"strconv"
@@ -41,6 +41,19 @@ func main() {
 	}
 }
 
+type VCAPServices struct {
+    NFS []struct {
+        Credentials    map[string]string   `json:"credentials"`
+        Label          string              `json:"label"`
+        Name           string              `json:"name"`
+        Plan           string              `json:"plan"`
+        Provider       string              `json:"provider"`
+        SyslogDrainURL string              `json:"syslog_drain_url"`
+        Tags           []string            `json:"tags"`
+        VolumeMounts   []map[string]string `json:"volume_mounts"`
+    } `json:"nfs"`
+}
+
 type VCAPApplication struct {
 	InstanceIndex int `json:"instance_index"`
 }
@@ -49,20 +62,25 @@ func hello(res http.ResponseWriter, req *http.Request) {
 	fmt.Fprintf(res, "instance index: %s", os.Getenv("INSTANCE_INDEX"))
 }
 
+func LoadVCAPServices(input string) (VCAPServices, error) {
+    var config VCAPServices
+    configFile := strings.NewReader(input)
+
+    jsonParser := json.NewDecoder(configFile)
+    err := jsonParser.Decode(&config)
+
+    return config, err
+}
+
 func getPath() string {
-	r, err := regexp.Compile("\"container_(dir|path)\": \"([^\"]+)\"")
-	if err != nil {
-		panic(err)
-	}
+    vcapEnv := os.Getenv("VCAP_SERVICES")
+    config, err := LoadVCAPServices(vcapEnv)
+    if err != nil {
+        panic(err)
+    }
 
-	vcapEnv := os.Getenv("VCAP_SERVICES")
-	match := r.FindStringSubmatch(vcapEnv)
-	if len(match) < 3 {
-		fmt.Fprintf(os.Stderr, "VCAP_SERVICES is %s", vcapEnv)
-		panic("failed to find container_dir in environment json")
-	}
-
-	return match[2]
+    // the first mount will be used if more than one is attached
+    return config.NFS[0].VolumeMounts[0]["container_dir"]
 }
 
 func write(res http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
The `getPath()` function in server.go causes the application to panic and crash. This is because the regular expression is failing to find matches in the VCAP_SERVICES environment variable. To fix this I have refactored the function to load the VCAP_SERVICES into a struct, rather than using a regular expression. See example error below:

```
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR VCAP_SERVICES is {"nfs":[{"credentials":{},"label":"nfs","name":"myVolume","plan":"Existing","provider":null,"syslog_drain_url":null,"tags":["nfs"],"volume_mounts":[{"container_dir":"/home/vcap/data","device_type":"shared","mode":"rw"}]}]}2018/01/17 19:29:19 http: panic serving <REDACTED-IP>:34988: failed to find container_dir in environment json
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR goroutine 10 [running]:
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR net/http.(*conn).serve.func1(0xc420092a00)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /usr/local/go/src/net/http/server.go:1721 +0xd0
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR panic(0x652c80, 0xc420011280)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /usr/local/go/src/runtime/panic.go:489 +0x2cf
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR main.getPath(0x7c5e20, 0x6c2748)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /go/src/app/server.go:62 +0x1f3
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR main.write(0x7c8ca0, 0xc4200f00e0, 0xc42000ac00)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /go/src/app/server.go:69 +0x34
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR net/http.HandlerFunc.ServeHTTP(0x6c2748, 0x7c8ca0, 0xc4200f00e0, 0xc42000ac00)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /usr/local/go/src/net/http/server.go:1942 +0x44
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR net/http.(*ServeMux).ServeHTTP(0x7f3f40, 0x7c8ca0, 0xc4200f00e0, 0xc42000ac00)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /usr/local/go/src/net/http/server.go:2238 +0x130
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR net/http.serverHandler.ServeHTTP(0xc4200a02c0, 0x7c8ca0, 0xc4200f00e0, 0xc42000ac00)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /usr/local/go/src/net/http/server.go:2568 +0x92
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR net/http.(*conn).serve(0xc420092a00, 0x7c91a0, 0xc42005ca00)
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /usr/local/go/src/net/http/server.go:1825 +0x612
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR created by net/http.(*Server).Serve
2018-01-17T19:29:19.53+0000 [APP/PROC/WEB/0] ERR    /usr/local/go/src/net/http/server.go:2668 +0x2ce
```