### PR TITLE
Fix deprecated manifest properties

### DIFF
--- a/assets/pora/manifest.yml
+++ b/assets/pora/manifest.yml
@@ -1,4 +1,6 @@
 ---
+applications:
+- name: pora
   buildpack: go_buildpack
   env:
     GOPACKAGENAME: pora


### PR DESCRIPTION
The `buildpack` and `env` properties should be nested inside an application instead of being declared at the top level: https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated